### PR TITLE
No longer installing PHPUnit globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Command                  | Value
 `make clean`             | Stop, then remove, all containers
 `make ssh`               | SSH into the web server container
 `make ssh-root`          | SSH into the web server container, as root
-`make test`              | Run tests
+`make test`              | Executes `./www/test.sh` within the context of the web server container
 `make ssl-create`        | Creates a new LetsEncrypt SSL certificate
 `make ssl-renew`         | Renews a previously created LetsEncrypt SSL certificate
 

--- a/docker/scripts/test.sh
+++ b/docker/scripts/test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-if [ -f ./www/phpunit.xml ]; then
-    docker-compose exec --user=1000:1000 webserver phpunit
+if [ -f ./www/test.sh ]; then
+    docker-compose exec --user=1000:1000 webserver ./test.sh
 fi

--- a/docker/webserver/apache-laravel-php72/Dockerfile
+++ b/docker/webserver/apache-laravel-php72/Dockerfile
@@ -38,10 +38,6 @@ RUN useradd -u 1000 -m www-bridge-user && \
     # Install: composer
     curl -sS https://getcomposer.org/installer | php && \
     mv composer.phar /usr/bin/composer && \
-    # Install: phpunit
-    curl -sS https://phar.phpunit.de/phpunit-6.5.phar -o phpunit-6.5.phar && \
-    chmod +x phpunit-6.5.phar && \
-    mv phpunit-6.5.phar /usr/bin/phpunit && \
     # Enable: Apache modules
     a2enmod rewrite && \
     a2enmod ssl && \

--- a/docker/webserver/apache-nails-php72/Dockerfile
+++ b/docker/webserver/apache-nails-php72/Dockerfile
@@ -38,10 +38,6 @@ RUN useradd -u 1000 -m www-bridge-user && \
     # Install: composer
     curl -sS https://getcomposer.org/installer | php && \
     mv composer.phar /usr/bin/composer && \
-    # Install: phpunit
-    curl -sS https://phar.phpunit.de/phpunit-6.5.phar -o phpunit-6.5.phar && \
-    chmod +x phpunit-6.5.phar && \
-    mv phpunit-6.5.phar /usr/bin/phpunit && \
     # Install: Nails Command Line Tool
     git clone https://github.com/nails/command-line-tool ~/nails-command-line-tool && \
     mv ~/nails-command-line-tool/nails /usr/bin/nails && \

--- a/docker/webserver/apache-php56/Dockerfile
+++ b/docker/webserver/apache-php56/Dockerfile
@@ -37,10 +37,6 @@ RUN useradd -u 1000 -m www-bridge-user && \
     # Install: composer
     curl -sS https://getcomposer.org/installer | php && \
     mv composer.phar /usr/bin/composer && \
-    # Install: phpunit
-    curl -sS https://phar.phpunit.de/phpunit-5.7.9.phar -o phpunit-5.7.9.phar && \
-    chmod +x phpunit-5.7.9.phar && \
-    mv phpunit-5.7.9.phar /usr/bin/phpunit && \
     # Enable: Apache modules
     a2enmod rewrite && \
     a2enmod ssl && \

--- a/docker/webserver/apache-php72/Dockerfile
+++ b/docker/webserver/apache-php72/Dockerfile
@@ -38,10 +38,6 @@ RUN useradd -u 1000 -m www-bridge-user && \
     # Install: composer
     curl -sS https://getcomposer.org/installer | php && \
     mv composer.phar /usr/bin/composer && \
-    # Install: phpunit
-    curl -sS https://phar.phpunit.de/phpunit-6.5.phar -o phpunit-6.5.phar && \
-    chmod +x phpunit-6.5.phar && \
-    mv phpunit-6.5.phar /usr/bin/phpunit && \
     # Enable: Apache modules
     a2enmod rewrite && \
     a2enmod ssl && \

--- a/docker/webserver/apache-wordpress-php72/Dockerfile
+++ b/docker/webserver/apache-wordpress-php72/Dockerfile
@@ -38,10 +38,6 @@ RUN useradd -u 1000 -m www-bridge-user && \
     # Install: composer
     curl -sS https://getcomposer.org/installer | php && \
     mv composer.phar /usr/bin/composer && \
-    # Install: phpunit
-    curl -sS https://phar.phpunit.de/phpunit-6.5.phar -o phpunit-6.5.phar && \
-    chmod +x phpunit-6.5.phar && \
-    mv phpunit-6.5.phar /usr/bin/phpunit && \
     # Enable: Apache modules
     a2enmod rewrite && \
     a2enmod ssl && \


### PR DESCRIPTION
Preferring vendored install and then configuring in the `test.sh` file at the project root. This allows for more advanced configurations as well as not enforcing PHPUnit.